### PR TITLE
fix: added correct format for posts in hashtag search

### DIFF
--- a/src/repository/hashtags.repository.js
+++ b/src/repository/hashtags.repository.js
@@ -17,10 +17,39 @@ export function getTopHashtagsDB(){
 }
 
 export function getPostsByHashtagDB(params){
+    /*
+    A ROTA ESTÁ SEM VERIFICAÇÃO DE LIKES. Quando for adicionada autenticação,
+    recuperar o id do usuário aqui e utilizar no comando EXISTS().
+    */
     const {hashtag} = params
     return db.query(`
-        SELECT posts.* FROM hashtags
-            JOIN posts ON posts.id=hashtags."postId"
-                WHERE hashtag=$1;`
-                ,[hashtag]);
+    SELECT
+        u.username,
+        u.image,
+        json_build_object(
+            'id', p.id,
+            'url', p.url,
+            'description', p.description,
+            'createdAt', p."createdAt",
+            'likes', COUNT(l.id),
+            'liked', EXISTS(SELECT 1 FROM likes WHERE "postId" = p.id AND "userId" = 1)
+        ) AS post,
+        json_agg(h.hashtag) AS hashtags
+    FROM
+        users u 
+        JOIN posts p ON u.id = p."userId"
+        LEFT JOIN likes l ON p.id = l."postId"
+        LEFT JOIN hashtags h ON p.id = h."postId"        
+        WHERE h.hashtag=$1
+    GROUP BY
+        u.username,
+        u.image,
+        p.id,
+        p.url,
+        p.description,
+        p."createdAt"
+    ORDER BY
+        p."createdAt" DESC;
+        `
+        ,[hashtag]);
 }


### PR DESCRIPTION
Agora envia corretamente o post no formato esperado. A única coisa que falta é adicionar autenticação, aí fica visível se foi curtido.